### PR TITLE
Move to using prebuild docker image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ services:
   - docker
 
 before_install:
-  - docker build -t "koji_wrapper" --file=containers/Dockerfile.fedora .
+  - docker pull releasedepot/koji_wrapper:fedora27
 
 # Command to run tests, e.g. python setup.py test
 script:
-  - docker run --privileged -v `pwd`:/tmp/koji_wrapper --user=koji -w="/tmp/koji_wrapper" -it koji_wrapper:latest /bin/bash -l -c "make dev; make test-all"
+  - docker run --privileged -v `pwd`:/tmp/koji_wrapper --user=koji -w="/tmp/koji_wrapper" -it releasedepot/koji_wrapper:fedora27 /bin/bash -l -c "make dev; make test-all"
 
 # Assuming you have installed the travis-ci CLI tool, after you
 # create the Github repo and add it to Travis, run the


### PR DESCRIPTION
Building the image for every pull request inside travis is very slow.
This should speed up our CI and open us up to more quickly testing on
other distros.

Signed-off-by: Jason Guiditta <jason.guiditta@gmail.com>