### PR TITLE
Stub out koji in conf.py for readthedocs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,21 @@ sys.path.insert(0, os.path.abspath('..'))
 
 import koji_wrapper
 
+# the following is needed for readthedocs, since they will not have the required
+# C libraries, see documentation @:
+# https://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
+from unittest.mock import MagicMock
+
+class Mock(MagicMock):
+        @classmethod
+        def __getattr__(cls, name):
+            return MagicMock()
+
+MOCK_MODULES = ['koji']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
+
+
 # -- General configuration ---------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
RTD does not have all required C libraries (specifically, at least rpm,
since they run on an ubuntu docker container).  Their documentation does
what this patch does as an example, so the build will not fail.

Signed-off-by: Jason Guiditta <jason.guiditta@gmail.com>