### PR TITLE
Move methods that deal directly with the session object into base class.

### DIFF
--- a/koji_wrapper/base.py
+++ b/koji_wrapper/base.py
@@ -53,3 +53,17 @@ class KojiWrapperBase(object):
         else:
             self.__session = koji.ClientSession(self.url)
 
+    def build(self, nvr):
+        """
+        :param nvr: nvr of the desired build
+        :returns: build object from koji
+        """
+        return self.session.getBuild(nvr)
+
+    def archives(self, **kwargs):
+        """
+        :param **kwargs: Any valid named parameter accepted by the koji client's
+            listArchives method
+        :returns: list of archives from koji
+        """
+        return self.session.listArchives(**kwargs)

--- a/koji_wrapper/wrapper.py
+++ b/koji_wrapper/wrapper.py
@@ -9,24 +9,9 @@ from koji_wrapper.base import KojiWrapperBase
 
 class KojiWrapper(KojiWrapperBase):
 
-    def build(self, nvr):
-        """
-        :param nvr: of the desired build
-        :returns: build object from koji
-        """
-        return self.session.getBuild(nvr)
-
-    def archives(self, **kwargs):
-        """
-        :param **kwargs: Any valid named parameter accepted by the koji client's
-            listArchives method
-        :returns: list of archives from koji
-        """
-        return self.session.listArchives(**kwargs)
-
     def file_types(self, nvr, types=['image']):
         """
-        :param nvr: of the desired build:
+        :param nvr: nvr of the desired build
         :param types: list of koji archive types.  This is currently any of:
             'maven', 'win', or 'image'
         :returns: list of file types of given build


### PR DESCRIPTION
The idea is to have base become a 'simple client' over time, which the
other object that inherit from it will expand on.  Any method that deals
with the kojiClient object directly will go in here, and eventually, a
caching mechanism as well.

Signed-off-by: Jason Guiditta <jason.guiditta@gmail.com>