### PR TITLE
Add method to retrieve srpm_url to KojiWrapper.

### DIFF
--- a/koji_wrapper/base.py
+++ b/koji_wrapper/base.py
@@ -53,17 +53,34 @@ class KojiWrapperBase(object):
         else:
             self.__session = koji.ClientSession(self.url)
 
+    def archives(self, **kwargs):
+        """
+        :param **kwargs: Any valid named parameter accepted by the koji client's
+            listArchives method:
+            https://pagure.io/koji/blob/master/f/hub/kojihub.py#_3950
+        :returns: list of archives from koji
+        """
+        return self.session.listArchives(**kwargs)
+
     def build(self, nvr):
         """
+        This method wraps the koji client method getBuild:
+        https://pagure.io/koji/blob/master/f/hub/kojihub.py#_3477
+
         :param nvr: nvr of the desired build
         :returns: build object from koji
         """
         return self.session.getBuild(nvr)
 
-    def archives(self, **kwargs):
+    def rpms(self, **kwargs):
         """
         :param **kwargs: Any valid named parameter accepted by the koji client's
-            listArchives method
-        :returns: list of archives from koji
+            listArchives method:
+            https://pagure.io/koji/blob/master/f/hub/kojihub.py#_3723
+        :returns: list of matching rpms from koji
         """
-        return self.session.listArchives(**kwargs)
+        # TODO: make this always returns a list, so the client can rely on it
+        return self.session.listRPMs(**kwargs)
+
+    def _handle_exception():
+        pass

--- a/koji_wrapper/wrapper.py
+++ b/koji_wrapper/wrapper.py
@@ -5,6 +5,7 @@ Wraps a connection to koji, managing the session, and providing convenience
 methods for interacting with the koji api.
 """
 
+import koji
 from koji_wrapper.base import KojiWrapperBase
 
 class KojiWrapper(KojiWrapperBase):
@@ -33,3 +34,35 @@ class KojiWrapper(KojiWrapperBase):
         # Default
         #TODO: make sure we actually need this default - can't see why we do.
         return ['rpm']
+
+    def srpm_url(self, nvr=None):
+        """
+        :param nvr: reference to the rpm of the desired package.  This may be
+        any of:
+            - int ID
+            - string N-V-R.A
+            - string N-V-R.A@location
+            - map containing 'name', 'version', 'release', and 'arch' (and
+              optionally 'location')
+        :returns: srpm url for a given nvr
+        """
+        try:
+            build = self.build(nvr)
+            rpm_list = self.rpms(buildID=build.get('build_id'))
+            src_rpm = None
+            for rpm in rpm_list:
+                if rpm.get('arch') == 'src':
+                    src_rpm = rpm
+                    break
+            return self._build_srpm_url(rpm=src_rpm, build=build)
+        except Exception as inst:
+            # TODO: either add logging or decide if we want to do more to handle
+            # errors here.
+            raise inst
+
+    def _build_srpm_url(rpm=None, build=None):
+        # TODO: add error handling.
+        path = koji.PathInfo(topdir=self.topurl)
+        srpm_path = path.rpm(rpm)
+        base_path = path.build(build)
+        return base_path + '/' + srpm_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def sample_build():
             'completion_ts': 1519943592.64899,
             'owner_id': 1527,
             'owner_name': 'someone',
-            'nvr': 'my-project-9.0-20190301.1.el7ost',
+            'nvr': 'my-project-9.0-20190301.1.el7',
             'start_time': '2018-03-01 22:07:52.627945',
             'creation_event_id': 18416869,
             'start_ts': 1519942072.62794,
@@ -27,12 +27,56 @@ def sample_build():
             'name': 'my-project',
             'task_id': 15464337,
             'volume_name': 'DEFAULT',
-            'release': '20190301.1.el7ost'}
+            'release': '20190301.1.el7'}
+
+@pytest.fixture()
+def sample_rpm_list():
+    return [
+        {
+            'build_id': 670920,
+            'nvr': 'my-project-9.0-20190301.1.el7',
+            'extra': None,
+            'buildroot_id': 3837636,
+            'buildtime': 1523295721,
+            'payloadhash': '42731f7fc0b4db65573cd6615a1200fe',
+            'epoch': None,
+            'version': '9.0',
+            'metadata_only': False,
+            'external_repo_id': 0,
+            'release': '20190301.1.el7',
+            'size': 80084,
+            'arch': 'noarch',
+            'id': 5531502,
+            'external_repo_name': 'INTERNAL',
+            'name': 'my-project'
+        },
+        {
+            'build_id': 670920,
+            'nvr': 'my-project-9.0-20190301.1.el7',
+            'extra': None,
+            'buildroot_id': 3837636,
+            'buildtime': 1523295718,
+            'payloadhash': '7bebd0e2cdee9e07709aa22a7273d10b',
+            'epoch': None,
+            'version': '9.0',
+            'metadata_only': False,
+            'external_repo_id': 0,
+            'release': '20190301.1.el7',
+            'size': 111828,
+            'arch': 'src',
+            'id': 5531501,
+            'external_repo_name': 'INTERNAL',
+            'name': 'my-project'
+        }
+    ]
+
 
 @pytest.fixture()
 def sample_archives():
-    return [{'build_id': 666503, 
-            'type_name': 'xml', 
+    return [
+        {
+            'build_id': 666503,
+            'type_name': 'xml',
             'type_id': 5,
             'checksum': '5ccff657de1e95f3ec4f6bbaaa807a64', 
             'extra': None,
@@ -45,8 +89,10 @@ def sample_archives():
             'btype_id': 4,
             'buildroot_id': None,
             'id': 2383603,
-            'size': 674},
-            {'build_id': 666503,
+            'size': 674
+        },
+        {
+            'build_id': 666503,
             'type_name': 'ks',
             'type_id': 38,
             'checksum': '7b628c55169c29977e2765e22f067816',
@@ -60,8 +106,10 @@ def sample_archives():
             'btype_id': 4,
             'buildroot_id': None,
             'id': 2383604,
-            'size': 444},
-            {'build_id': 666503,
+            'size': 444
+        },
+        {
+            'build_id': 666503,
             'type_name': 'rpm',
             'type_id': 38,
             'checksum': 'ecd81413754e88b3907de740e5992275',
@@ -75,8 +123,10 @@ def sample_archives():
             'btype_id': 4,
             'buildroot_id': None,
             'id': 2383605,
-            'size': 2076},
-            {'build_id': 666503,
+            'size': 2076
+        },
+        {
+            'build_id': 666503,
             'type_name': 'image',
             'type_id': 5,
             'checksum': 'acd4059c1af628de2d4cad777f69d151',
@@ -90,8 +140,10 @@ def sample_archives():
             'btype_id': 4,
             'buildroot_id': None,
             'id': 2383606,
-            'size': 1384},
-            {'build_id': 666503,
+            'size': 1384
+        },
+        {
+            'build_id': 666503,
             'type_name': 'qcow2',
             'type_id': 28,
             'checksum': '615019a6c1db5a16fe0dee2f577ef06e',
@@ -105,5 +157,7 @@ def sample_archives():
             'btype_id': 4,
             'buildroot_id': None,
             'id': 2383607,
-            'size': 778874368}]
+            'size': 778874368
+        }
+    ]
 

--- a/tests/unit/test_koji_wrapper.py
+++ b/tests/unit/test_koji_wrapper.py
@@ -84,9 +84,25 @@ def test_returns_file_types(a_koji_wrapper, sample_archives):
     a_koji_wrapper.session.listArchives = \
         MagicMock(return_value=sample_archives)
     a_koji_wrapper.session.getBuild = MagicMock(return_value={'id':'12345'})
-    ft = a_koji_wrapper.file_types('myproject-9.0-20190326.1.el7ost')
+    ft = a_koji_wrapper.file_types('myproject-9.0-20190326.1.el7')
     assert a_koji_wrapper.session.getBuild.called
     assert a_koji_wrapper.session.listArchives.called
     assert isinstance(ft,list)
     assert 'image' in ft
+
+def test_returns_srpm_url(a_koji_wrapper, sample_build, sample_rpm_list):
+    """
+    GIVEN we have a valid KojiWrapper with a session,
+    WHEN we call the srpm_url method with a valid nvr,
+    THEN we get a string representation of the srpm url for the given nvr
+    """
+    a_koji_wrapper.build = \
+        MagicMock(return_value=sample_build)
+    a_koji_wrapper.rpms = MagicMock(return_value=sample_rpm_list)
+    a_koji_wrapper._build_srpm_url = \
+        MagicMock(return_value='http://my.kojiserver/rpms/something.src.rpm')
+    srpm_url = a_koji_wrapper.srpm_url('myproject-9.0-20190326.1.el7')
+    assert a_koji_wrapper.session.getBuild.called
+    assert a_koji_wrapper.session.listRPMs.called
+    assert isinstance(srpm_url,str)
 


### PR DESCRIPTION
This method is used to get a direct url for download of an srpm.

Signed-off-by: Jason Guiditta <jason.guiditta@gmail.com>