### PR TITLE
Fix KojiWrapper._build_srpm_url()

### DIFF
--- a/koji_wrapper/wrapper.py
+++ b/koji_wrapper/wrapper.py
@@ -15,7 +15,7 @@ class KojiWrapper(KojiWrapperBase):
 
     def __init__(self, **kwargs):
         self._pathinfo = None
-        super(KojiWrapper, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def file_types(self, nvr, types=['image']):
         """

--- a/koji_wrapper/wrapper.py
+++ b/koji_wrapper/wrapper.py
@@ -4,11 +4,18 @@
 Wraps a connection to koji, managing the session, and providing convenience
 methods for interacting with the koji api.
 """
+import os
 
 import koji
+
 from koji_wrapper.base import KojiWrapperBase
 
+
 class KojiWrapper(KojiWrapperBase):
+
+    def __init__(self, **kwargs):
+        self._pathinfo = None
+        super(KojiWrapper, self).__init__(**kwargs)
 
     def file_types(self, nvr, types=['image']):
         """
@@ -63,8 +70,11 @@ class KojiWrapper(KojiWrapperBase):
             raise inst
 
     def _build_srpm_url(self, rpm=None, build=None):
+
+        if self._pathinfo is None and self.topurl is not None:
+            self._pathinfo = koji.PathInfo(topdir=self.topurl)
+
         # TODO: add error handling.
-        path = koji.PathInfo(topdir=self.topurl)
-        srpm_path = path.rpm(rpm)
-        base_path = path.build(build)
-        return base_path + '/' + srpm_path
+        srpm_path = self._pathinfo.rpm(rpm)
+        base_path = self._pathinfo.build(build)
+        return os.path.join(base_path, srpm_path)

--- a/koji_wrapper/wrapper.py
+++ b/koji_wrapper/wrapper.py
@@ -62,7 +62,7 @@ class KojiWrapper(KojiWrapperBase):
             # errors here.
             raise inst
 
-    def _build_srpm_url(rpm=None, build=None):
+    def _build_srpm_url(self, rpm=None, build=None):
         # TODO: add error handling.
         path = koji.PathInfo(topdir=self.topurl)
         srpm_path = path.rpm(rpm)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,26 @@ def sample_rpm_list():
         }
     ]
 
+@pytest.fixture()
+def sample_srpm():
+    return {
+        'build_id': 670920,
+        'nvr': 'my-project-9.0-20190301.1.el7',
+        'extra': None,
+        'buildroot_id': 3837636,
+        'buildtime': 1523295718,
+        'payloadhash': '7bebd0e2cdee9e07709aa22a7273d10b',
+        'epoch': None,
+        'version': '9.0',
+        'metadata_only': False,
+        'external_repo_id': 0,
+        'release': '20190301.1.el7',
+        'size': 111828,
+        'arch': 'src',
+        'id': 5531501,
+        'external_repo_name': 'INTERNAL',
+        'name': 'my-project'
+    }
 
 @pytest.fixture()
 def sample_archives():


### PR DESCRIPTION
- Add unit tests showing error in KojiWrapper._build_srpm_url()
- add missing self parameter
- add unit tests for bad input
- add stub unit test for good case due to mocking issues