### PR TITLE
Add support to initialize KojiWrapperBase from session

### DIFF
--- a/koji_wrapper/base.py
+++ b/koji_wrapper/base.py
@@ -50,6 +50,11 @@ class KojiWrapperBase(object):
             self.__session = newsession
         elif issubclass(type(newsession), KojiWrapperBase):
             self.__session = newsession.session
+            if self.url is None or self.url == '':
+                self.url = newsession.url
+
+            if self.topurl is None or self.topurl == '':
+                self.topurl = newsession.topurl
         else:
             self.__session = koji.ClientSession(self.url)
 

--- a/tests/unit/test_koji_wrapper.py
+++ b/tests/unit/test_koji_wrapper.py
@@ -62,6 +62,20 @@ def test_init_with_koji_wrapper():
     assert test_wrapper.session is my_koji_wrapper.session
 
 
+def test_init_with_koji_wrapper_only():
+    """
+    GIVEN we have a valid KojiWrapper with a session,
+    WHEN a KojiWrapper object is passed as the session to a new KojiWrapper
+    THEN this object's session is set to the session and url/topurl
+    """
+    my_koji_wrapper = build_wrapper(None)
+    test_wrapper = KojiWrapper(session=my_koji_wrapper)
+    assert isinstance(test_wrapper.session, koji.ClientSession)
+    assert test_wrapper.session is my_koji_wrapper.session
+    assert test_wrapper.url is my_koji_wrapper.url
+    assert test_wrapper.topurl is my_koji_wrapper.topurl
+
+
 def test_gets_build(a_koji_wrapper, sample_build):
     """
     GIVEN we have a valid KojiWrapper with a session,


### PR DESCRIPTION
- add unittest showing use case
- add check in KojiWrapperBase to initialize from session

This allow you to take an existing KojiWrapper object and
construct another KojiWrapperBase derivitve with only
session parameter provided

some_existing_wrapper

new_wrapper = KojiWrapper(session=some_existing_wrapper)

and the resulting wrapper created by this has all content initialized
correctly.

Closes: Issue #28 