### PR TITLE
Get srpm improvement

### DIFF
--- a/koji_wrapper/wrapper.py
+++ b/koji_wrapper/wrapper.py
@@ -57,7 +57,7 @@ class KojiWrapper(KojiWrapperBase):
         """
         try:
             build = self.build(nvr)
-            rpm_list = self.rpms(buildID=build.get('build_id'))
+            rpm_list = self.rpms(buildID=build.get('build_id'), arches='src')
             src_rpm = None
             for rpm in rpm_list:
                 if rpm.get('arch') == 'src':

--- a/tests/unit/test_koji_wrapper.py
+++ b/tests/unit/test_koji_wrapper.py
@@ -130,8 +130,9 @@ def test_returns_srpm_url(a_koji_wrapper, sample_build, sample_rpm_list):
     a_koji_wrapper._build_srpm_url = \
         MagicMock(return_value='http://my.kojiserver/rpms/something.src.rpm')
     srpm_url = a_koji_wrapper.srpm_url('myproject-9.0-20190326.1.el7')
-    assert a_koji_wrapper.session.getBuild.called
-    assert a_koji_wrapper.session.listRPMs.called
+    assert a_koji_wrapper.build.called
+    assert a_koji_wrapper.rpms.called
+    assert a_koji_wrapper._build_srpm_url.called
     assert isinstance(srpm_url, str)
 
 


### PR DESCRIPTION
Reduce extra data retrieved across the network by only asking for arches=src when requesting listRPMs call to koji client.