### PR TITLE
Add ability to pass extra parameters to KojiTag.builds method.

### DIFF
--- a/koji_wrapper/tag.py
+++ b/koji_wrapper/tag.py
@@ -58,12 +58,18 @@ class KojiTag(KojiWrapper):
     def tagged_list(self, tagged_list):
             self.__tagged_list = tagged_list
 
-    def builds(self):
+    def builds(self, **kwargs):
         """
+        This method wraps the koji client method listTagged:
+
+            https://pagure.io/koji/blob/master/f/hub/kojihub.py
+
+        :param **kwargs: Any valid named parameter accepted by the koji
+                client method listTagged:
         :returns: list of matching tagged build objects from koji
         """
         if self.tagged_list is None:
-            self._filter_tagged(self.session.listTagged(self.tag))
+            self._filter_tagged(self.session.listTagged(self.tag, **kwargs))
         return self.tagged_list
 
     def _filter_tagged(self, tagged_builds):

--- a/tests/unit/test_koji_tag.py
+++ b/tests/unit/test_koji_tag.py
@@ -73,6 +73,20 @@ def test_gets_builds(sample_tagged_builds):
     assert kt.session.listTagged.called
 
 
+def test_passes_builds_extra_args(sample_tagged_builds):
+    """
+    GIVEN we have a KojiTag object
+    WHEN we call the builds() method for the first time with a parameter
+    THEN the tagged builds should be returned
+    AND the listTagged method of the session object should be called
+        with the expected parameter.
+    """
+    kt = build_tag('foo')
+    kt.session.listTagged = MagicMock(return_value=sample_tagged_builds)
+    assert kt.builds(inherit=True) == sample_tagged_builds
+    assert kt.session.listTagged.called_with(inherit=True)
+
+
 def test_caches_builds(sample_tagged_builds):
     """
     GIVEN we have a KojiTag object


### PR DESCRIPTION
This exposes the underlying abilities of the koji api listTagged method, so that
if a user wants to pass in extra filters that the api supports, they can do so.

Closes #25 #26 #27

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>