### PR TITLE
Set mergify to not automerge if WIP label is set.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,6 +7,7 @@ rules:
           - continuous-integration/travis-ci
       required_pull_request_reviews:
         required_approving_review_count: 1
+    disabling_label: WIP
     merge_strategy:
       method: rebase
       rebase_fallback: merge


### PR DESCRIPTION
Ti use this, simply set the label on your PR in github[1].  Once you are
ready for it to be merged, remove the label.

[1] https://help.github.com/articles/about-labels/

Signed-off-by: Jason Guiditta <jason.guiditta@gmail.com>