### PR TITLE
Add methods to return certain attributes from the tagged builds list.

### DIFF
--- a/koji_wrapper/tag.py
+++ b/koji_wrapper/tag.py
@@ -87,3 +87,44 @@ class KojiTag(KojiWrapper):
     def latest_by_nvr(self):
         # TODO: implement/port _find_latest logic
         pass
+
+    def builds_by_attribute(self, attribute):
+        """
+        Return a list of the specified attribute, extracted from the list of
+        tagged builds.  For instance, you may call with 'nvr' to get back the
+        list of NVRs in your build list.  Throws a KeyError if you request an
+        attribute that does not exist in the build objects.
+
+        :param attribute: Any attribute (or key) from a build object, such as
+                          'nvr', 'name', etc.
+        :returns: a list of strings
+        :raises KeyError: if attribute passed is invalid
+
+        """
+
+        # covers brewtag.components and brewtag.builds cases
+        return [build[attribute] for build in self.tagged_list]
+
+    def builds_by_attribute_and_label(self, attribute, label, match):
+        """
+        Return a list of the specified attribute, filtered by matching labels,
+        extracted from the list of tagged builds.  For instance, you may call
+        with 'nvr', 'name', 'foo' to get back the list of NVRs in your build
+        list for items with a name of 'foo'.  Throws a KeyError if you request
+        an attribute that does not exist in the build objects.
+
+        :param attribute: Any attribute (or key) from a build object, such as
+                          'nvr', 'name', etc.
+        :param label: Any label (or key) from a build object, which you wish to
+                      use to filter your results, such as 'nvr', 'name', etc.
+        :param match: Value you are looking to match for the label that was
+                      passed in.
+
+        :returns: a list of strings
+        :raises KeyError: if attribute passed is invalid
+
+        """
+
+        # covers brewtag.builds_package case
+        return [build[attribute] for build in self.tagged_list
+                if build[label] == match]

--- a/tests/unit/test_koji_tag.py
+++ b/tests/unit/test_koji_tag.py
@@ -143,3 +143,66 @@ def test_filters_builds_by_both(sample_tagged_builds):
     kt.session.listTagged = MagicMock(return_value=sample_tagged_builds)
     filtered = kt._filter_tagged(sample_tagged_builds)
     assert len(filtered) == 0
+
+
+def test_gets_attribute_for_builds_in_list(sample_tagged_builds):
+    """
+    GIVEN we have a KojiTag object
+    WHEN we call builds_by_attribute with the desired attribute name
+    THEN we get back a list of values for that attribute name from the list of
+        builds.
+    """
+
+    kt = build_tag('foo')
+    kt.tagged_list = sample_tagged_builds
+    nvrs = kt.builds_by_attribute('nvr')
+    assert len(kt.tagged_list) == 2
+    assert len(nvrs) == 2
+    assert nvrs[0] == 'my-project-selinux-0.8.14-13.el7ost'
+
+
+def test_invalid_attribute_for_builds_in_list(sample_tagged_builds):
+    """
+    GIVEN we have a KojiTag object
+    WHEN we call builds_by_attribute with an invalid attribute name
+    THEN we get a KeyError.
+    """
+
+    kt = build_tag('foo')
+    kt.tagged_list = sample_tagged_builds
+    with pytest.raises(KeyError):
+        nvrs = kt.builds_by_attribute('farkle') # NOQA
+
+
+def test_builds_by_attribute_and_label(sample_tagged_builds):
+    """
+    GIVEN we have a KojiTag object
+    WHEN we call builds_by_attribute_and_label with the desired attribute name
+        and label,
+    THEN we get back a list of values for that attribute name from the list of
+        builds where the label also matches.
+    """
+
+    kt = build_tag('foo')
+    kt.tagged_list = sample_tagged_builds
+    nvrs = kt.builds_by_attribute_and_label('nvr',
+                                            'name',
+                                            'my-project-selinux')
+    assert len(kt.tagged_list) == 2
+    assert len(nvrs) == 1
+    assert nvrs[0] == 'my-project-selinux-0.8.14-13.el7ost'
+
+
+def test_invalid_builds_by_attribute_and_label(sample_tagged_builds):
+    """
+    GIVEN we have a KojiTag object
+    WHEN we call builds_by_attribute_and_label with an invalid attribute name
+    THEN we get a KeyError.
+    """
+
+    kt = build_tag('foo')
+    kt.tagged_list = sample_tagged_builds
+    with pytest.raises(KeyError):
+        kt.builds_by_attribute_and_label('farkle',
+                                         'name',
+                                         'my-project-selinux')


### PR DESCRIPTION
This allows you, for example, to get a list of all the NVRs for your tag
object's list of builds, or the NVRs just for builds of a certain
package.

Signed-off-by: Jason Guiditta <jason.guiditta@gmail.com>