### PR TITLE
Add support for koji profiles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ install: init ## install the package to the active Python's site-packages
 	pipenv run python setup.py install
 
 dev: init ## set up a development environment
+	pipenv --three # This is here in case your system python is 2.x
 	pipenv install --dev
 	pipenv run pip install -e .
 

--- a/tests/unit/data/mykoji.conf
+++ b/tests/unit/data/mykoji.conf
@@ -1,0 +1,8 @@
+[mykoji]
+server = https://mykoji.foo.org/kojihub/
+weburl = https://mykoji.foo.org/koji
+topurl = http://mykoji.foo.org/kojifiles
+topdir = /mnt/koji
+cert = ~/.foo.cert
+ca = ~/.foo-server-ca.cert
+serverca = /etc/ssl/certs/ca-bundle.crt

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,0 +1,47 @@
+"""
+Test the KojiBase class
+"""
+
+
+import koji
+import pytest
+# from unittest.mock import MagicMock
+from koji_wrapper.base import KojiWrapperBase
+
+
+def test_parses_config(shared_datadir):
+    """
+    GIVEN we have a profile defined in a user-specified directory
+    WHEN we create a koji.ClientSession object
+    THEN we should successfully create a Client using this profile.
+    """
+
+    tw = KojiWrapperBase(profile='mykoji',
+                         user_config=shared_datadir / 'mykoji.conf')
+    assert tw.profile == 'mykoji'
+    assert isinstance(tw.session, koji.ClientSession)
+
+
+def test_config_throws_error_on_no_file():
+    """
+    GIVEN we do NOT have the expected file defined in the specified
+        location
+    WHEN we try to create a koji.ClientSession object
+    THEN we should get back a koji.ConfigurationError
+    """
+
+    with pytest.raises(koji.ConfigurationError):
+        KojiWrapperBase(profile='mykoji',
+                        user_config='/tmp/not_a_file.conf')
+
+
+def test_config_throws_error_on_no_profile():
+    """
+    GIVEN we do NOT have the profile defined in the standard location koji
+        looks
+    WHEN we try to create a koji.ClientSession object
+    THEN we should get back a koji.ConfigurationError
+    """
+
+    with pytest.raises(koji.ConfigurationError):
+        KojiWrapperBase(profile='not_a_profile')

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ passenv=HOME
 deps = pipenv
 basepython = python
 commands =
-    pipenv install --dev --ignore-pipfile
+    pipenv install --dev
+    pipenv run pip install -e .
     pipenv run flake8 --version
     pipenv run flake8 setup.py koji_wrapper tests
     pipenv run flake8 docs


### PR DESCRIPTION
Koji profiles can be installed in system locations or a user config
directly, and optionally, the user can supply an additional
file/directory to override default settings that may be in the system
locations.  This patch enables both of these to be passed in, in
addition to the simple case of having a url to perform read-only
operations against a koji instance.

Fixes #37

Signed-off-by: Jason Guiditta <jason.guiditta@gmail.com>