### PR TITLE
setup.py: Add missing pytest-datadir to test_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = ['koji', 'toolchest']
 
 setup_requirements = ['pytest-runner', ]
 
-test_requirements = ['pytest', ]
+test_requirements = ['pytest', 'pytest-datadir', ]
 
 setup(
     author="Jason Guiditta",


### PR DESCRIPTION
found when trying to do simple testing to reproduce how a user of this might check to see if library has everything and is working on their environment.

using pipenv as a convenience but could do same with virtualenv

pipenv --threee
pipenv install
pipenv run setup.py pytest

Failures:
- testing would fail with fixture shared_datadir not found
  => Needed pytest-datadir

after adding entry it succeeds