### PR TITLE
tag: Add __str__ to return tag

### DIFF
--- a/koji_wrapper/tag.py
+++ b/koji_wrapper/tag.py
@@ -19,6 +19,10 @@ class KojiTag(KojiWrapper):
         self.tagged_list = None
         super().__init__(**kwargs)
 
+    def __str__(self):
+        """return tag as description(str for human)"""
+        return self.tag
+
     @property
     def tag(self):
         """:param tag: tag to filter results with."""

--- a/tests/unit/test_koji_tag.py
+++ b/tests/unit/test_koji_tag.py
@@ -206,3 +206,13 @@ def test_invalid_builds_by_attribute_and_label(sample_tagged_builds):
         kt.builds_by_attribute_and_label('farkle',
                                          'name',
                                          'my-project-selinux')
+
+
+def test_str_returns_tag():
+    """
+    GIVEN we have a KojiTag object
+    WHEN we call through to the __str__() method
+    THEN we get back a string with the tag it was based on
+    """
+    kt = build_tag('foo')
+    assert 'foo' == str(kt)


### PR DESCRIPTION
- add a basic str to KojiTag to return the tag it's based on
- add a sanity unittest for implemented function

http://thomas-cokelaer.info/blog/2017/12/difference-between-__repr__-and-__str__-in-python/