### PR TITLE
Add support for login.

### DIFF
--- a/tests/unit/data/ssl_koji.conf
+++ b/tests/unit/data/ssl_koji.conf
@@ -1,9 +1,8 @@
-[mykoji]
+[ssl_koji]
 server = https://mykoji.foo.org/kojihub/
 weburl = https://mykoji.foo.org/koji
 topurl = http://mykoji.foo.org/kojifiles
 topdir = /mnt/koji
-authtype = kerberos
 cert = ~/.foo.cert
 ca = ~/.foo-server-ca.cert
 serverca = /etc/ssl/certs/ca-bundle.crt

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -5,7 +5,7 @@ Test the KojiBase class
 
 import koji
 import pytest
-# from unittest.mock import MagicMock
+from unittest.mock import MagicMock
 from koji_wrapper.base import KojiWrapperBase
 
 
@@ -45,3 +45,64 @@ def test_config_throws_error_on_no_profile():
 
     with pytest.raises(koji.ConfigurationError):
         KojiWrapperBase(profile='not_a_profile')
+
+
+def test_logs_in_w_kerberos(shared_datadir):
+    """
+    GIVEN we have a profile that has an authtype of 'kerberos'
+    WHEN we try to log in with a koji client that is kinit'ed
+    THEN we should get back True and successfully log in.
+    """
+
+    tw = KojiWrapperBase(profile='mykoji',
+                         user_config=shared_datadir / 'mykoji.conf')
+    tw.session.krb_login = MagicMock(return_value=True)
+    logged_in = tw.login()
+    assert tw.profile == 'mykoji'
+    assert logged_in is True
+    assert tw.session.krb_login.called
+
+
+def test_fails_krb_login_wo_ticket(shared_datadir):
+    """
+    GIVEN we have a profile that has an authtype of 'kerberos'
+    WHEN we try to log in with a koji client that is not kinit'ed
+    THEN we should get back an AuthError and not be logged in.
+    """
+
+    tw = KojiWrapperBase(profile='mykoji',
+                         user_config=shared_datadir / 'mykoji.conf')
+    logged_in = tw.login()
+    assert tw.profile == 'mykoji'
+    assert logged_in is False
+
+
+def test_logs_in_w_ssl(shared_datadir):
+    """
+    GIVEN we have a profile that connects via ssl
+    WHEN we try to log in with a koji client that has the correct credentials
+    THEN we should get back True and successfully log in.
+    """
+
+    tw = KojiWrapperBase(profile='ssl_koji',
+                         user_config=shared_datadir / 'ssl_koji.conf')
+    tw.session.ssl_login = MagicMock(return_value=True)
+    logged_in = tw.login()
+    assert tw.profile == 'ssl_koji'
+    assert logged_in is True
+    assert tw.session.ssl_login.called
+
+
+def test_fails_login_w_bad_ssl(shared_datadir):
+    """
+    GIVEN we have a profile that connects via ssl
+    WHEN we try to log in with a koji client that does not have the correct
+    credentials
+    THEN we should get back an AuthError and not be logged in.
+    """
+
+    tw = KojiWrapperBase(profile='ssl_koji',
+                         user_config=shared_datadir / 'ssl_koji.conf')
+    logged_in = tw.login()
+    assert tw.profile == 'ssl_koji'
+    assert logged_in is False


### PR DESCRIPTION
For the initial pass, login will be called directly, but in the future,
we will do some behind the scenes checking to log in the client only if
an api method is called that requires login.