### PR TITLE
Use gssapi_login instead of deprecated krb_login

### DIFF
--- a/koji_wrapper/base.py
+++ b/koji_wrapper/base.py
@@ -156,7 +156,7 @@ class KojiWrapperBase(object):
         """
         try:
             if self.session.opts.get('authtype') == 'kerberos':
-                return self.session.krb_login()
+                return self.session.gssapi_login()
             else:
                 return self.session.ssl_login()
         except koji.AuthError as e:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -56,14 +56,14 @@ def test_logs_in_w_kerberos(shared_datadir):
 
     tw = KojiWrapperBase(profile='mykoji',
                          user_config=shared_datadir / 'mykoji.conf')
-    tw.session.krb_login = MagicMock(return_value=True)
+    tw.session.gssapi_login = MagicMock(return_value=True)
     logged_in = tw.login()
     assert tw.profile == 'mykoji'
     assert logged_in is True
-    assert tw.session.krb_login.called
+    assert tw.session.gssapi_login.called
 
 
-def test_fails_krb_login_wo_ticket(shared_datadir):
+def test_fails_gssapi_login_wo_ticket(shared_datadir):
     """
     GIVEN we have a profile that has an authtype of 'kerberos'
     WHEN we try to log in with a koji client that is not kinit'ed


### PR DESCRIPTION
The krb_login function is deprecated and should not be used [1].
Use the suggested gssapi_login function instead.

[1] https://pagure.io/koji/blob/master/f/koji/__init__.py#_2499