### PR TITLE
Update deprecated action versions.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Setup System Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+          python: ['3.8', '3.9', '3.10', '3.11']
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
             python-version: ${{ matrix.python }}
         - name: Setup System Dependencies
@@ -21,18 +21,16 @@ jobs:
             sudo apt update
             sudo apt install libkrb5-dev -y
         - name: Install Tox and any other packages
-          run: |
-            python -m pip install --upgrade pip
-            pip install tox tox-gh-actions
+          run: pip install tox
         - name: Run Tox
           # Run tox using the version of Python in `PATH`
           run: tox -epy
     flake8:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
             python-version: 3.11
         - name: Setup System Dependencies
@@ -40,17 +38,15 @@ jobs:
             sudo apt update
             sudo apt install libkrb5-dev -y
         - name: Install Tox and any other packages
-          run: |
-            python -m pip install --upgrade pip
-            pip install tox tox-gh-actions
+          run: pip install tox
         - name: Lint with flake8
           run: tox -eflake8
     twine:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
             python-version: 3.11
         - name: Setup System Dependencies
@@ -58,8 +54,6 @@ jobs:
             sudo apt update
             sudo apt install libkrb5-dev -y
         - name: Install Tox and any other packages
-          run: |
-            python -m pip install --upgrade pip
-            pip install tox tox-gh-actions
+          run: pip install tox
         - name: Run twine-check
           run: tox -etwine


### PR DESCRIPTION
Github has moved workers to a new node [1], so we need to update those actions before the old node is decommissioned.

[1] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/